### PR TITLE
fix: fix restarting video on android

### DIFF
--- a/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -301,7 +301,9 @@ class ReactExoplayerView extends FrameLayout implements
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        initializePlayer();
+        // uncommented `initializePlayer()`, because it caused video to restart when it is running
+        // behind another screen and the user navigated back to the screen where the video runs
+        // initializePlayer();
     }
 
     @Override
@@ -1477,6 +1479,7 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
+                Log.d("PLAYER", "reload1");
                 reloadSource();
             }
         }
@@ -1514,6 +1517,7 @@ class ReactExoplayerView extends FrameLayout implements
             this.mediaDataSourceFactory = buildDataSourceFactory(true);
 
             if (!isSourceEqual) {
+                Log.d("PLAYER", "reload2");
                 reloadSource();
             }
         }
@@ -1521,6 +1525,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setTextTracks(ReadableArray textTracks) {
         this.textTracks = textTracks;
+        Log.d("PLAYER", "reload3");
         reloadSource();
     }
 


### PR DESCRIPTION
On Android, video was restarted when it played behind another screen and user navigated back to the screen where the video runs. 