### PR TITLE
fix: add own fullscreendiddismiss observer

### DIFF
--- a/ios/Video/RCTPlayerDelegate.swift
+++ b/ios/Video/RCTPlayerDelegate.swift
@@ -11,11 +11,13 @@ class RCTPlayerDelegate: NSObject, AVPlayerViewControllerDelegate {
     private var _onPictureInPictureStatusChanged: RCTDirectEventBlock?
     private var _onVideoFullscreenPlayerWillPresent: RCTDirectEventBlock?
     private var _onVideoFullscreenPlayerWillDismiss: RCTDirectEventBlock?
+    private var _onVideoFullscreenPlayerDidDismiss: RCTDirectEventBlock?
         
-    init(_ onPictureInPictureStatusChanged: RCTDirectEventBlock?, _ onVideoFullscreenPlayerWillPresent: RCTDirectEventBlock?, _ onVideoFullscreenPlayerWillDismiss: RCTDirectEventBlock?) {
+    init(_ onPictureInPictureStatusChanged: RCTDirectEventBlock?, _ onVideoFullscreenPlayerWillPresent: RCTDirectEventBlock?, _ onVideoFullscreenPlayerWillDismiss: RCTDirectEventBlock?, _ onVideoFullscreenPlayerDidDismiss: RCTDirectEventBlock?) {
         _onPictureInPictureStatusChanged = onPictureInPictureStatusChanged
         _onVideoFullscreenPlayerWillPresent = onVideoFullscreenPlayerWillPresent
         _onVideoFullscreenPlayerWillDismiss = onVideoFullscreenPlayerWillDismiss
+        _onVideoFullscreenPlayerDidDismiss = onVideoFullscreenPlayerDidDismiss
     }
     
     func playerViewControllerDidStartPictureInPicture(_ playerViewController: AVPlayerViewController) {
@@ -36,7 +38,10 @@ class RCTPlayerDelegate: NSObject, AVPlayerViewControllerDelegate {
         
     }
     
-    func playerViewController(_ playerViewController: AVPlayerViewController, willEndFullScreenPresentationWithAnimationCoordinator: UIViewControllerTransitionCoordinator) {
+    func playerViewController(_ playerViewController: AVPlayerViewController, willEndFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: nil, completion: { _ in
+            self._onVideoFullscreenPlayerDidDismiss?([:])
+                })
         
         _onVideoFullscreenPlayerWillDismiss?([:])
         

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -736,7 +736,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
                 self.removePlayerLayer()
                 self.usePlayerViewController()
                 if (_playerViewController !== nil) {
-                    _playerDelegate = RCTPlayerDelegate(self.onPictureInPictureStatusChanged, self.onVideoFullscreenPlayerWillPresent, self.onVideoFullscreenPlayerWillDismiss)
+                    _playerDelegate = RCTPlayerDelegate(self.onPictureInPictureStatusChanged, self.onVideoFullscreenPlayerWillPresent, self.onVideoFullscreenPlayerWillDismiss, self.onVideoFullscreenPlayerDidDismiss)
                     _playerViewController!.delegate = _playerDelegate
                 }
             }
@@ -780,8 +780,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
             _playerViewController = nil
             _playerObserver.playerViewController = nil
             self.applyModifiers()
-
-            onVideoFullscreenPlayerDidDismiss?(["target": reactTag as Any])
+            // Moved to RCTPlayerDelegate
+            // onVideoFullscreenPlayerDidDismiss?(["target": reactTag as Any])
         }
     }
 


### PR DESCRIPTION
- adds custom fullscreen did dismiss observer, because existing one did not fire when fullscreen got dismissed via native controls and not via calling `dismissFullscreenPlayer()` method